### PR TITLE
Ignore empty string detail

### DIFF
--- a/src/ProblemDocument.ts
+++ b/src/ProblemDocument.ts
@@ -37,7 +37,9 @@ export class ProblemDocument {
     // const result = {
     this.type = type
     this.title = title
-    this.detail = detail
+    if (detail) {
+      this.detail = detail
+    }
     this.instance = instance
     this.status = status
     // };

--- a/test/ProblemDocumentTests.ts
+++ b/test/ProblemDocumentTests.ts
@@ -67,6 +67,16 @@ describe('When creating a Problem Document with detail member', (): void => {
   })
 })
 
+describe('When creating a Problem Document with empty string detail', (): void => {
+  it('should not contain detail member', (done): void => {
+    const doc = new ProblemDocument({ detail: '' })
+
+    doc.should.not.have.property('detail')
+
+    return done()
+  })
+})
+
 describe('When creating a Problem Document with instance member', (): void => {
   it('should contain instance member', (done): void => {
     const instance = '/account/12345/msgs/abc'


### PR DESCRIPTION
I skip the `detail` when it is an empty string to prevent `detail: ""` in the response