### PR TITLE
feat: simplify problem details extensions

### DIFF
--- a/src/ProblemDocument.ts
+++ b/src/ProblemDocument.ts
@@ -8,7 +8,7 @@ export class ProblemDocument {
   public title: string
   public type?: string
 
-  public constructor (options: ProblemDocumentOptions, extension?: ProblemDocumentExtension) {
+  public constructor (options: ProblemDocumentOptions, extension?: ProblemDocumentExtension | Record<string, any>) {
     const detail = options.detail
     const instance = options.instance
     let type = options.type
@@ -43,9 +43,13 @@ export class ProblemDocument {
     // };
 
     if (extension) {
-      for (const propertyName in extension.extensionProperties) {
-        if (extension.extensionProperties.hasOwnProperty(propertyName)) {
-          this[propertyName] = extension.extensionProperties[propertyName]
+      const extensionProperties = extension instanceof ProblemDocumentExtension
+        ? extension.extensionProperties
+        : extension
+
+      for (const propertyName in extensionProperties) {
+        if (extensionProperties.hasOwnProperty(propertyName)) {
+          this[propertyName] = extensionProperties[propertyName]
         }
       }
     }
@@ -61,9 +65,9 @@ export class ProblemDocumentOptions {
 }
 
 export class ProblemDocumentExtension {
-  public extensionProperties: any;
+  public extensionProperties: Record<string, any>;
 
-  public constructor (extensionProperties: any) {
+  public constructor (extensionProperties: Record<string, any>) {
     this.extensionProperties = extensionProperties
   }
 }

--- a/src/ProblemDocument.ts
+++ b/src/ProblemDocument.ts
@@ -8,7 +8,7 @@ export class ProblemDocument {
   public title: string
   public type?: string
 
-  public constructor (options: ProblemDocumentOptions, extension?: ProblemDocumentExtension | Record<string, any>) {
+  public constructor (options: ProblemDocumentOptions, extension?: ProblemDocumentExtension | Record<string, Object>) {
     const detail = options.detail
     const instance = options.instance
     let type = options.type
@@ -65,9 +65,9 @@ export class ProblemDocumentOptions {
 }
 
 export class ProblemDocumentExtension {
-  public extensionProperties: Record<string, any>;
+  public extensionProperties: Record<string, Object>;
 
-  public constructor (extensionProperties: Record<string, any>) {
+  public constructor (extensionProperties: Record<string, Object>) {
     this.extensionProperties = extensionProperties
   }
 }

--- a/test/ProblemDocumentTests.ts
+++ b/test/ProblemDocumentTests.ts
@@ -43,6 +43,19 @@ describe('When creating a Problem Document with an Extension', (): void => {
 
     return done()
   })
+
+  it('should contain extension added as plain object', (done): void => {
+    const type = 'http://tempuri.org/my-problem'
+    const title = `something went wrong`
+    const extensionName = 'invalid-params'
+    const extensionValue = 'test'
+    const extension = { 'invalid-params': extensionValue }
+    const doc = new ProblemDocument({ type, title }, extension)
+
+    doc[extensionName].should.equal(extensionValue)
+
+    return done()
+  })
 })
 
 describe('When creating a Problem Document with status member', (): void => {


### PR DESCRIPTION
I propose to simplify how extension properties are added to a problem details object. The `ProblemDocumentExtension` is IMO redundant and I would consider removing in the future. Instead the `Record<>` types is just what the extension is about, adding more key-value pairs to the response.